### PR TITLE
Heptio Quickstart Update

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && apk add --no-cache curl
 # curl kubectl instead of ADD'ing it, since we want to cache the layer
 RUN curl -sfL \
       -o /usr/local/bin/kubectl \
-      https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl && \
+      https://storage.googleapis.com/kubernetes-release/release/v1.7.6/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 RUN apk add --no-cache \

--- a/packer/payload/prepare-ami.sh
+++ b/packer/payload/prepare-ami.sh
@@ -14,7 +14,7 @@
 #    limitations under the License.
 
 SOURCE_DIR="$(cd "$(dirname "$0")"; pwd)"
-KUBERNETES_RELEASE="v1.7.4"
+KUBERNETES_RELEASE="v1.7.6"
 CNI_RELEASE="0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"
 
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D

--- a/scripts/kubernetes-override-binaries.sh.in
+++ b/scripts/kubernetes-override-binaries.sh.in
@@ -27,7 +27,7 @@ for binary in kubelet kubeadm kubectl; do
     url=${url_base%/}/$binary
 
     echo "Attempting to download: $url"
-    if /usr/bin/curl -f -o /tmp/$binary "$url"; then
+    if /usr/bin/curl -Lf -o /tmp/$binary "$url"; then
         md5=($(/usr/bin/md5sum /tmp/$binary))
         echo "Installing override binary $binary with md5sum: $md5"
         /usr/bin/install -o root -g root -m 0755 /tmp/$binary /usr/bin/$binary

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -264,33 +264,33 @@ Mappings:
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
     us-west-1:
-      '64': ami-77201417
+      '64': ami-28300048
     ap-south-1:
-      '64': ami-a75612c8
+      '64': ami-28773647
     eu-west-2:
-      '64': ami-4dc8d829
+      '64': ami-57594b33
     eu-west-1:
-      '64': ami-1844bf61
+      '64': ami-8331fafa
     ap-northeast-2:
-      '64': ami-ef4b9381
+      '64': ami-11c3197f
     ap-northeast-1:
-      '64': ami-d303fbb5
+      '64': ami-d4eb3fb2
     sa-east-1:
-      '64': ami-516b183d
+      '64': ami-0184f86d
     ca-central-1:
-      '64': ami-6040fe04
+      '64': ami-f363da97
     ap-southeast-1:
-      '64': ami-1cadcf7f
+      '64': ami-4c5d2f2f
     ap-southeast-2:
-      '64': ami-3886635a
+      '64': ami-fd84649f
     eu-central-1:
-      '64': ami-64f7420b
+      '64': ami-2a972445
     us-east-1:
-      '64': ami-833b32f8
+      '64': ami-312ddf4b
     us-east-2:
-      '64': ami-b8dcffdd
+      '64': ami-ce270aab
     us-west-2:
-      '64': ami-e58b619d
+      '64': ami-9143bae9
 
 # Helper Conditions which help find the right values for resources
 Conditions:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -40,7 +40,7 @@ Metadata:
       - InstanceType
       - DiskSizeGb
       - ClusterSubnetId
-      - LoadBalancerSubnetId      
+      - LoadBalancerSubnetId
     - Label:
         default: Access Configuration
       Parameters:
@@ -187,7 +187,7 @@ Parameters:
   # Specifies the IP range from which you will have SSH access over port 22
   # Used in the allow22 SecurityGroup
   SSHLocation:
-    Description: CIDR block (IP address range) to allow SSH access to the 
+    Description: CIDR block (IP address range) to allow SSH access to the
       instances. Use 0.0.0.0/0 to allow access from all locations.
     Type: String
     MinLength: '9'
@@ -223,11 +223,11 @@ Parameters:
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase
       letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
       (-).
-    
+
     Default: quickstart-reference
     Description: Only change this if you have set up assets, like your own networking
       configuration, in an S3 bucket. This and the S3 Key Prefix parameter let you access
-      scripts from the scripts/ and templates/ directories of your own fork of the Heptio 
+      scripts from the scripts/ and templates/ directories of your own fork of the Heptio
       Quick Start assets, uploaded to S3 and stored at
       ${bucketname}.s3.amazonaws.com/${prefix}/scripts/somefile.txt.S3. The bucket name
       can include numbers, lowercase letters, uppercase letters, and hyphens (-).
@@ -253,7 +253,7 @@ Parameters:
     ConstraintDescription: 'Currently supported values are "calico" and "weave"'
     Default: calico
     Description: Choose the networking provider to use for communication between
-      pods in the Kubernetes cluster. Supported configurations are calico 
+      pods in the Kubernetes cluster. Supported configurations are calico
       (http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/)
       and weave (https://github.com/weaveworks/weave/blob/master/site/kube-addon.md).
     Type: String


### PR DESCRIPTION
* Bumps k8s version to 1.7.6
* Adds ability to override kubeadm, kubectl, kubelet with custom ones from an s3 bucket